### PR TITLE
Warning when stderr has output

### DIFF
--- a/tasks/exec.js
+++ b/tasks/exec.js
@@ -63,6 +63,10 @@ module.exports = function(grunt) {
         callback(err);
         return;
       }
+		if(stderr) {
+			callback(stderr);
+			return;
+		}
       if (logStdout) {
         log.write(stdout);
       }


### PR DESCRIPTION
In the course of normal execution programs shouldn't be outputting to `stderr` unless there is a problem, so I changed the task so that if `stderr` has content that content is thrown as a warning and grunt stops there.
