### PR TITLE
Migrate to v0.4 of Grunt

### DIFF
--- a/tasks/exec.js
+++ b/tasks/exec.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
 
   var task = grunt.task;
   var file = grunt.file;
-  var utils = grunt.utils;
+  var util = grunt.util;
   var log = grunt.log;
   var verbose = grunt.verbose;
   var fail = grunt.fail;
@@ -34,11 +34,11 @@ module.exports = function(grunt) {
       return false;
     }
 
-    if (utils._.isFunction(data.command)) {
+    if (util._.isFunction(data.command)) {
         data.command = data.command(grunt);
     }
 
-    if (!utils._(data.command).isString()) {
+    if (!util._(data.command).isString()) {
       grunt.warn('The command property must be a string.');
       return false;
     }
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
     var done = this.async();
 
     verbose.subhead(data.command);
-    grunt.helper('exec', data.command, function(err, stdout) {
+    cp.exec(data.command, function(err, stdout) {
       // if configured, log stdout
       data.stdout && stdout && log.write(stdout);
 
@@ -67,3 +67,4 @@ module.exports = function(grunt) {
     });
   };
 };
+


### PR DESCRIPTION
Applied required fixes for compatibility with new version (0.4) of Grunt
More details here: https://github.com/gruntjs/grunt/wiki/Upgrading-from-0.3-to-0.4
