### PR TITLE
Add option to specify expected exit code from exec'd program

### DIFF
--- a/tasks/exec.js
+++ b/tasks/exec.js
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
     o.stderr && childProcess.stderr.on('data', function (d) { log.error(d); });
 
     childProcess.on('exit', function(code) {
-      if (code !== o.exitCode) {
+      if (code > 0 && code !== o.exitCode) {
         log.error(f('Exited with code: %d.', code));
         return done(false);
       }


### PR DESCRIPTION
Added a configuration option allowing the task to succeed if the exec'd program returns a non-zero exit code matching that configured in the option ('exitCode').  The specific use-case for this is execution of Windows Explorer targeted on an output directory - Explorer returns an exit code of 1 (!)
