### PR TITLE
Provide an option to handle the data event

### DIFF
--- a/tasks/exec.js
+++ b/tasks/exec.js
@@ -17,6 +17,8 @@ module.exports = function(grunt) {
       , stdout = data.stdout !== undefined ? data.stdout : true
       , stderr = data.stderr !== undefined ? data.stderr : true
       , callback = _.isFunction(data.callback) ? data.callback : function() {}
+      , onOutData = _.isFunction(data.onOutData) ? data.onOutData : function (d) { log.write(d); }
+      , onErrData = _.isFunction(data.onErrData) ? data.onErrData : function (d) { log.write(d); }
       , exitCode = data.exitCode || 0
       , command
       , childProcess
@@ -49,8 +51,8 @@ module.exports = function(grunt) {
 
     childProcess = cp.exec(command, execOptions, callback);
 
-    stdout && childProcess.stdout.on('data', function (d) { log.write(d); });
-    stderr && childProcess.stderr.on('data', function (d) { log.error(d); });
+    stdout && childProcess.stdout.on('data', onOutData);
+    stderr && childProcess.stderr.on('data', onErrData);
 
     childProcess.on('exit', function(code) {
       if (code !== exitCode) {


### PR DESCRIPTION
It would be nice if users can create their own custom functions to handle the data event. 
I'm executing a command that checks my php files for syntax errors. 
I would like to be able parse each output as it comes and check if there are no errors, otherwise exit the process.
## Example

```

---
    exec: {
        test: {
            cmd: "find ./component -name '*.php' -exec php -l {} ;",

            onOutData: function (data) {
                console.log(data);

                if (data.match(/Errors parsing|PHP Parse error/g)) {
                    process.exit(1);
                }
            },

            onErrData: function (data) {
                console.log(data);

                if (data.match(/Errors parsing|PHP Parse error/g)) {
                    process.exit(1);
                }
            }
    }

---
```
