### PR TITLE
Run tests on Windows and support outputProperty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swp
 
 node_modules
+.idea/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ grunt-exec will assume an error has occurred and will abort grunt immediately.
   for multiple allowed exit codes.
 *  __callback__: The callback function passed `child_process.exec`. Defaults to 
   a noop.
+* __outputProperty__: Name of a grunt property whose value will be the stdout
+  of the command
 
 If the configuration is instead a simple `string`, it will be
 interpreted as a full command itself:

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "test": "/usr/bin/env node test/test.js"
+    "test": "node test/test.js"
   },
   "peerDependencies": {
     "grunt": "~0.4"

--- a/tasks/exec.js
+++ b/tasks/exec.js
@@ -16,8 +16,12 @@ module.exports = function(grunt) {
       , execOptions = data.options !== undefined ? data.options : {}
       , stdout = data.stdout !== undefined ? data.stdout : true
       , stderr = data.stderr !== undefined ? data.stderr : true
-      , callback = _.isFunction(data.callback) ? data.callback : function() {}
+      , defaultCallback = function(err, stdout, stderr) {
+          outputProperty && grunt.config(outputProperty, stdout.toString());
+        }
+      , callback = _.isFunction(data.callback) ? data.callback : defaultCallback
       , exitCodes = data.exitCode || data.exitCodes || 0
+      , outputProperty = data.outputProperty
       , command
       , childProcess
       , args = [].slice.call(arguments, 0)

--- a/test/Gruntfile.js
+++ b/test/Gruntfile.js
@@ -2,24 +2,24 @@ module.exports = function(grunt) {
   grunt.initConfig({
     exec: {
       test1: {
-        cmd: 'echo "bruce willis was dead" > test1'
+        cmd: 'echo bruce willis was dead> test1'
       }
     , test2: {
-        cmd: function() { return 'echo "grunt@' + this.version + '" > test2'; }
+        cmd: function() { return 'echo grunt@' + this.version + '> test2'; }
       }
     , test3: {
         cmd: function(answerToLife, tacoThoughts) {
           var text = [
             'the answer to life is ' + answerToLife
           , 'thoughts on tacos? ' + tacoThoughts
-          ].join('\n');
+          ].join(', ');
 
-          return 'echo "' + text + '" > test3';
+          return 'echo ' + text + '> test3';
         }
       }
     , test4: {
         cmd: function(){
-          return 'echo "you can use callback, and error, stdout, stderr can be used as arguments"';
+          return 'echo you can use callback, and error, stdout, stderr can be used as arguments';
         }
       , callback: function(error, stdout, stderr){
           var fs = require('fs')
@@ -38,7 +38,11 @@ module.exports = function(grunt) {
         cmd: 'exit 9'
       , exitCodes: [8, 9]
       }
-    , test7: 'echo "you don\'t even need an object" > test7'
+    , test7: 'echo you do not even need an object> test7'
+    , test8: {
+        cmd: 'echo hello',
+        outputProperty: 'test8Output'
+      }
     }
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 var grunt = require('grunt')
+  , lf = grunt.util.linefeed
   , path = require('path')
   , fs = require('fs')
   , assert = require('assert')
@@ -12,23 +13,24 @@ var grunt = require('grunt')
     , 'exec:test5'
     , 'exec:test6'
     , 'exec:test7'
+    , 'exec:test8'
     ];
 
 grunt.tasks(tasks, opts, function() {
   var tests = [
-        { name: 'test1', expected: 'bruce willis was dead\n' }
-      , { name: 'test2' , expected: 'grunt@' + grunt.version + '\n' }
+        { name: 'test1', expected: 'bruce willis was dead' + lf }
+      , { name: 'test2' , expected: 'grunt@' + grunt.version + lf }
       , {
           name: 'test3'
         , expected: [
-            'the answer to life is 42', 'thoughts on tacos? love', ''
-          ].join('\n')
+            'the answer to life is 42', 'thoughts on tacos? love'
+          ].join(', ') + lf
         }
       , {
           name: 'test4'
-        , expected:'you can use callback, and error, stdout, stderr can be used as arguments\n'
+        , expected:'you can use callback, and error, stdout, stderr can be used as arguments' + lf
         }
-      , { name: 'test7', expected: 'you don\'t even need an object\n' }
+      , { name: 'test7', expected: 'you do not even need an object' + lf }
       ]
     , outputPath;
 
@@ -41,4 +43,7 @@ grunt.tasks(tasks, opts, function() {
 
     grunt.log.ok(test.name +' passed');
   });
+
+  // test8
+  assert.equal(grunt.config('test8Output'), 'hello' + lf);
 });


### PR DESCRIPTION
I did some changes to be able to run tests correctly on Windows and added support for a new option, `outputProperty`, which will populate a grunt property with the same name as the value of the option with the contents of the standard output of the command.
