### PR TITLE
Check for child_process.exec() error events & output the failure string

### DIFF
--- a/tasks/exec.js
+++ b/tasks/exec.js
@@ -55,6 +55,13 @@ module.exports = function(grunt) {
     stdout && childProcess.stdout.on('data', function (d) { log.write(d); });
     stderr && childProcess.stderr.on('data', function (d) { log.error(d); });
 
+    // Catches failing to execute the command at all (eg spawn ENOENT),
+    // since in that case an 'exit' event will not be emitted.
+    childProcess.on('error', function (err) {
+      log.error(f('child_process.exec() failed with: %s', err));
+      done(false);
+    });
+
     childProcess.on('exit', function(code) {
       if (exitCodes.indexOf(code) < 0) {
         log.error(f('Exited with code: %d.', code));


### PR DESCRIPTION
If the child_process.exec() call fails entirely (eg spawn ENOENT due to not having the command interpreter on the PATH), then the child_process 'exit' event is never fired [1] - so prior to this patch nothing would have been output and the command would appear to complete successfully.

With this patch the task correctly returns as failing and something similar to this output to the grunt error log:

```
>> child_process.exec() failed with: Error: spawn ENOENT
```

This should avoid the confusion seen in https://github.com/jharding/grunt-exec/issues/47

[1] https://github.com/joyent/node/blob/b19b60a05c30fa4108c37ddfcabb9313655af652/lib/child_process.js#L1043
