### PR TITLE
Update version targeting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4"
+  - "5"
+  - "6"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-exec",
   "description": "Grunt task for executing shell commands.",
-  "version": "0.4.7",
+  "version": "1.0.0",
   "homepage": "https://github.com/jharding/grunt-exec",
   "author": {
     "name": "Jake Harding",
@@ -29,8 +29,8 @@
     "grunt": ">=0.4"
   },
   "devDependencies": {
-    "grunt": ">=0.4",
-    "grunt-contrib-jshint": ">=0.1"
+    "grunt": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0"
   },
   "keywords": [
     "grunt",


### PR DESCRIPTION
Now that Grunt 1.0.0 is out, it would be good to tag `grunt-exec@1.0.0` and test it across Node.js 4, 5 and 6.