### PR TITLE
Added synchronous support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ grunt-exec will assume an error has occurred and will abort grunt immediately.
   for multiple allowed exit codes.
 *  __callback__: The callback function passed `child_process.exec`. Defaults to 
   a noop.
+* __sync__: Whether to use `child_process.spawnSync`. Defaults to false.
 * __options__: Options to provide to `child_process.exec`. [NodeJS Documentation](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)
   - `cwd` String Current working directory of the child process
   - `env` Object Environment key-value pairs

--- a/test/Gruntfile.js
+++ b/test/Gruntfile.js
@@ -48,6 +48,21 @@ module.exports = function(grunt) {
       , shell: true
       }
     , test7: 'echo you do not even need an object> test7'
+    , test8: {
+      cmd: 'node -e "console.log(\'synchronous echo 1\'); process.exit(0);"',
+      sync: true,
+      shell: true
+    }
+    , test9: {
+      cmd: 'node -e "setTimeout(function () { console.log(\'synchronous echo 2, wait 3 seconds\'); process.exit(0); }, 3000);"',
+      sync: true,
+      shell: true
+    }
+    , test10: {
+      cmd: 'node -e "console.log(\'synchronous echo 3\'); process.exit(0);"',
+      sync: true,
+      shell: true
+    }
     }
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,9 @@ var grunt = require('grunt')
     , 'exec:test5'
     , 'exec:test6'
     , 'exec:test7'
+    , 'exec:test8'
+    , 'exec:test9'
+    , 'exec:test10'
     ];
 
 grunt.tasks(tasks, opts, function() {


### PR DESCRIPTION
Synchronous support (child_process.spawnSync instead of child_process.spawn) when sync:true is given (defaults to false)

Use case : blocking shell commands